### PR TITLE
Windows Containers sample with Seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,63 @@ websample_1   | [23:28:55 DBG] Connection id "0HKS3C80P1TVR" sent FIN with statu
 websample_1   | [23:28:55 DBG] Connection id "0HKS3C80P1TVR" stopped.
 consoleapp_1  | [23:28:57 INF] Serilog Console checking Web Sample at http://websample:5000 
 ```
+
+# Windows Containers samples
+
+## PreReqs
+
+* Windows Server 2016 ([evaluate](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2016))
+* Enable containers feature. See [MSDN documentation](https://msdn.microsoft.com/virtualization/windowscontainers/containers_welcome) for more details.
+* Docker tools
+
+### Quick setup
+```powershell
+# Add the containers feature and restart
+Install-WindowsFeature containers
+Restart-Computer -Force
+
+# Download, install Docker Engine, Docker Compose
+Invoke-WebRequest "https://download.docker.com/components/engine/windows-server/cs-1.12/docker.zip" -OutFile "$env:TEMP\docker.zip" -UseBasicParsing
+Expand-Archive -Path "$env:TEMP\docker.zip" -DestinationPath $env:ProgramFiles
+
+Invoke-WebRequest -Uri https://dl.bintray.com/docker-compose/master/docker-compose-Windows-x86_64.exe -OutFile $env:ProgramFiles\Docker\docker-compose.exe -UseBasicParsing
+
+# set PATH
+$env:Path += ";c:\program files\docker"
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\Docker", [EnvironmentVariableTarget]::Machine)
+
+# Configure Docker daemon to listen on both pipe and TCP
+dockerd.exe -H npipe:////./pipe/docker_engine -H 0.0.0.0:2375 --register-service
+
+# Start Docker daemon
+Start-Service docker
+```
+
+## Run the Samples
+
+This repo contains the following windows samples
+
+* Seq Event Server, based on [Windows Server 2016 Server Core](https://hub.docker.com/r/microsoft/windowsservercore/) image
+* Web App, based on [Windows Server 2016 Nano Server](https://hub.docker.com/r/microsoft/nanoserver/) image
+
+To run these, run `docker-compose -f samples-windows.yml up`
+
+Containers use `nat` network. To inspect what IPs they got run `docker network inspect nat` in the separate cmd shell and find your containers:
+```cmd
+"Containers": {
+    "5f66928248090245cc4313d8ff114a27e2a98ffaaf25f77518e6b7b8eb042c3a": {
+        "Name": "serilogdocker_web-sample_1",
+        "EndpointID": "1b18aae7a2bb05e3b82e7bd35a63595a7aef828041e77c4da61c6ca36537ed5e",
+        "IPv4Address": "172.23.144.124/16",
+        "IPv6Address": ""
+    },
+    "83313f0f78ca0447801ef29d1953e65be3d73e1d168c627e5593a255eedd1672": {
+        "Name": "serilogdocker_seq_1",
+        "EndpointID": "6649b52db115b5f7288e4a99fa298b7fe4f1991892abdbed9305cb175143e775",
+        "IPv4Address": "172.23.155.24/16",
+        "IPv6Address": ""
+    }
+}
+```
+
+Navigate to the Web App and Seq Web UI (`http://172.23.144.124:5000` and `http://172.23.155.24:5341/` accordingly for the example above) 

--- a/samples-windows.yml
+++ b/samples-windows.yml
@@ -1,0 +1,24 @@
+version: '2'
+
+services:      
+  seq:
+    build: ./seq
+    image: serilog-seq-server
+    ports:
+      - 5341:5341
+    tty: true
+  web-sample:
+    build: ./web-sample/src
+    image: serilog-web-sample
+    environment:
+      Serilog__WriteTo__1__Args__serverUrl: http://seq:5341/
+    depends_on:
+      - "seq"
+    ports:
+      - 5000:5000
+    tty: true    
+
+networks:
+  default:
+    external:
+      name: nat

--- a/seq/Dockerfile
+++ b/seq/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/windowsservercore
+
+LABEL Description="Seq Event Server" Vendor="Datalust" Version="3.3.23"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN Invoke-WebRequest https://getseq.net/Download/Begin?version=3.3.23 -OutFile c:\seq-installer.msi -UseBasicParsing ; \
+    Start-Process msiexec.exe -ArgumentList '/i c:\seq-installer.msi /quiet /norestart' -Wait ; \
+    Remove-Item c:\seq-installer.msi -Force 
+
+RUN seq install
+
+CMD Start-Service seq ; \
+    Write-Host Seq Event Server started... ; \
+    Get-NetAdapter | Get-NetIPAddress | ? AddressFamily -EQ 'IPv4' | select -ExpandProperty IPAddress ; \
+    while ($true) { Start-Sleep -Seconds 3600 }
+
+EXPOSE 5341

--- a/web-sample/src/Dockerfile
+++ b/web-sample/src/Dockerfile
@@ -1,0 +1,3 @@
+FROM microsoft/dotnet:1.0.0-preview2-nanoserver-onbuild
+
+EXPOSE 5000

--- a/web-sample/src/Program.cs
+++ b/web-sample/src/Program.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
+using System.IO;
 
 namespace aspnetcoreapp
 {
@@ -8,7 +8,8 @@ namespace aspnetcoreapp
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
-                .UseKestrel() 
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .UseUrls("http://0.0.0.0:5000")
                 .Build(); 

--- a/web-sample/src/Startup.cs
+++ b/web-sample/src/Startup.cs
@@ -1,12 +1,7 @@
-using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;  
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 
@@ -16,19 +11,16 @@ namespace aspnetcoreapp
     {
         public Startup(IHostingEnvironment env)
         {
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Debug()
-                .WriteTo.LiterateConsole()
-                .Enrich.FromLogContext() 
-                .CreateLogger();
-
-            var builder = new ConfigurationBuilder()
+            Configuration = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
- 
-            builder.AddEnvironmentVariables();
-            Configuration = builder.Build();
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(Configuration)
+                .CreateLogger();
         } 
         
         public IConfigurationRoot Configuration { get; }

--- a/web-sample/src/appsettings.json
+++ b/web-sample/src/appsettings.json
@@ -2,12 +2,24 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-WebSample-77a6427d-ecc6-4689-9514-5d4315948ee4;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
+      "Override": {
+        "System": "Information",
+        "Microsoft": "Information"
+      }
+    },
+    "WriteTo": [
+      { "Name": "LiterateConsole" },
+      {
+        "Name": "Seq",
+        "Args": {
+          "serverUrl": "http://localhost:5341/",
+          "compact": true
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext"]
   }
 }

--- a/web-sample/src/project.json
+++ b/web-sample/src/project.json
@@ -10,8 +10,9 @@
     },
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Serilog.Extensions.Logging": "1.0.0",
-    "Serilog.Sinks.Seq": "2.0.0",
+    "Serilog.Sinks.Seq": "3.0.1",
     "Serilog.Sinks.Literate": "2.0.0",
+    "Serilog.Settings.Configuration": "2.1.0",
     
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
     "Microsoft.AspNetCore.Diagnostics": "1.0.0", 


### PR DESCRIPTION
- dockerized `Seq`
- updated web-sample that can also run on `NanoServer` with overridable logging settings via `Serilog.Settings.Configuration` package and environment variables
- new sample-windows.yml with updated `readme.md`

Tested on Windows Server 2016 (can be run in VM). Individual containers can run on Windows 10 Pro / Ent with Hyper-V as well, but `docker-compose` according to [this blog post](https://blog.docker.com/2016/09/build-your-first-docker-windows-server-container/) don't work in Windows 10 for now. 
